### PR TITLE
disable sync of weekly patterns temporarily

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Sync Weekly Patterns and Home Panel Summary ...
         run: |
-          ./sg sync --name weekly_patterns
+         # ./sg sync --name weekly_patterns
           ./sg sync --name home_panel_summary
       
       - name: Sync GeoSupplement ...


### PR DESCRIPTION
#2 Updated end points. But the folders in weekly_patterns_test are not properly named. Disabling the sync of weekly_patterns for now. I'll need to fix the structure of subfolders within weekly_patterns_test